### PR TITLE
Add more available attributes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,7 @@ Get all interface parameters with ``get_values``. Following dictionary contains 
 
 List of parameters for interface:
 
-- BROADCAST, LOOPBACK, MULTICAST, RUNNING, UP, DYNAMIC
+- BROADCAST, LOOPBACK, MULTICAST, RUNNING, UP, DYNAMIC, NOARP, PROMISC
 - interface - Interface name, itype - Interface Type
 - ip - IP, bcast - Broadcast, mask - Mask
 - hwaddr - MAC address, mtu - MTU

--- a/ifparser/ifconfig.py
+++ b/ifparser/ifconfig.py
@@ -8,7 +8,7 @@ class Interface(object):
         'txbytes', 'rxbytes', 'rxpkts', 'txpkts'
     ])
     _flags = frozenset(
-        ['BROADCAST', 'MULTICAST', 'UP', 'RUNNING', 'LOOPBACK', 'DYNAMIC'])
+        ['BROADCAST', 'MULTICAST', 'UP', 'RUNNING', 'LOOPBACK', 'DYNAMIC', 'PROMISC'])
 
     def __init__(self, **kwargs):
         for k, v in kwargs.items():

--- a/ifparser/ifconfig.py
+++ b/ifparser/ifconfig.py
@@ -8,7 +8,7 @@ class Interface(object):
         'txbytes', 'rxbytes', 'rxpkts', 'txpkts'
     ])
     _flags = frozenset(
-        ['BROADCAST', 'MULTICAST', 'UP', 'RUNNING', 'LOOPBACK', 'DYNAMIC', 'PROMISC'])
+        ['BROADCAST', 'MULTICAST', 'UP', 'RUNNING', 'LOOPBACK', 'DYNAMIC', 'PROMISC', 'NOARP'])
 
     def __init__(self, **kwargs):
         for k, v in kwargs.items():


### PR DESCRIPTION
Hi @ssudake21 , 

Thanks for this amazing tool ! It really saves me a lot of time parsing ifconfig. I usually use -promisc flag to conduct networking experiment. However, I found a very tiny bug in your available flags list when I was using your tool.
```
Traceback (most recent call last):
  ...
  File "/home/mao/ifconfig-parser/ifparser/ifconfig.py", line 32, in __setattr__
    (name, value))
ValueError: Invalid attribute mentioned name=PROMISC value=True
```

According to the [ifconfig man page](https://linux.die.net/man/8/ifconfig)
> [-]arp
Enable or disable the use of the ARP protocol on this interface.
[-]promisc
Enable or disable the promiscuous mode of the interface. If selected, all packets on the network will be received by the interface.

Thus, I added two flags in ifconfig.py line 10: 
```python
_flags = frozenset(
        ['BROADCAST', 'MULTICAST', 'UP', 'RUNNING', 'LOOPBACK', 'DYNAMIC', 'PROMISC', 'NOARP'])
```
I test it with the interfaces below:
```
eth0      Link encap:Ethernet  HWaddr .....  
         ......
          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
          RX packets:1079082 errors:0 dropped:204078 overruns:0 frame:0
          TX packets:154015 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:1000 
          RX bytes:151909491 (151.9 MB)  TX bytes:30886210 (30.8 MB)
s3-eth2   Link encap:Ethernet  HWaddr 6e:05:75:1d:f8:c6  
          inet addr:127.0.0.1  Bcast:127.255.255.255  Mask:255.0.0.0
          inet6 addr: fe80::6c05:75ff:fe1d:f8c6/64 Scope:Link
          UP BROADCAST RUNNING NOARP PROMISC MULTICAST  MTU:1500  Metric:1
          RX packets:8 errors:0 dropped:0 overruns:0 frame:0
          TX packets:8 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:1000 
          RX bytes:648 (648.0 B)  TX bytes:648 (648.0 B)
```
The testing script looks like:
```python
ifdata = Ifcfg(commands.getoutput('ifconfig'))
for ni in ifdata.interfaces:
    print "interface %s has attribute PROMISC? %s" % (ni, ifdata.get_interface(ni).PROMISC)
    print "interface %s has attribute NOARP? %s" % (ni, ifdata.get_interface(ni).NOARP)
```
Result:
```
interface eth0 has attribute PROMISC? False
interface eth0 has attribute NOARP? False
interface s3-eth2 has attribute PROMISC? True
interface s3-eth2 has attribute NOARP? True
```
Hope it helps,
Chen-Nien
