### PR TITLE
Add support for SLAVE field from ifconfig output

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,7 +65,7 @@ Get all interface parameters with ``get_values``. Following dictionary contains 
 
 List of parameters for interface:
 
-- BROADCAST, LOOPBACK, MULTICAST, RUNNING, UP, DYNAMIC, NOARP, PROMISC
+- BROADCAST, LOOPBACK, MULTICAST, RUNNING, UP, DYNAMIC, NOARP, PROMISC, POINTTOPOINT, SIMPLEX, SMART, MASTER, SLAVE
 - interface - Interface name, itype - Interface Type
 - ip - IP, bcast - Broadcast, mask - Mask
 - hwaddr - MAC address, mtu - MTU

--- a/ifparser/ifconfig.py
+++ b/ifparser/ifconfig.py
@@ -13,7 +13,8 @@ class Interface(object):
     )
     _flag_list = (
         'BROADCAST', 'MULTICAST', 'UP', 'RUNNING', 'LOOPBACK', 'DYNAMIC',
-        'PROMISC', 'NOARP', 'POINTOPOINT', 'SIMPLEX', 'SMART', 'MASTER'
+        'PROMISC', 'NOARP', 'POINTOPOINT', 'SIMPLEX', 'SMART', 'MASTER',
+        'SLAVE'
     )
 
     _attrs = frozenset(_attr_list)

--- a/tests/iftest_6.txt
+++ b/tests/iftest_6.txt
@@ -1,0 +1,6 @@
+enp135s0f0 Link encap:Ethernet  HWaddr 3c:fd:fe:b9:2f:10
+          UP BROADCAST RUNNING SLAVE MULTICAST  MTU:9100  Metric:1
+          RX packets:83506277 errors:0 dropped:0 overruns:0 frame:0
+          TX packets:40450344 errors:0 dropped:0 overruns:0 carrier:0
+          collisions:0 txqueuelen:1000
+          RX bytes:47759052436 (47.7 GB)  TX bytes:21148910170 (21.1 GB)

--- a/tests/test_ifcfg_parser.py
+++ b/tests/test_ifcfg_parser.py
@@ -114,3 +114,20 @@ class IfcfgTestCase5(unittest.TestCase):
         self.assertEqual(_ifparser.interfaces,
                          ['eth1.60', 'eth1.60:1', 'gre0', 'ip6tnl0', 'lo',
                           'port_100_br0_l', 'rmnetctl', 'sit0'])
+
+
+class IfcfgTestCase6(unittest.TestCase):
+    def setUp(self):
+        fp = open('tests/iftest_6.txt', 'r')
+        data = fp.read()
+        fp.close()
+        self.ifparser = Ifcfg(data, debug=True)
+
+    def test_interface_slave_value(self):
+        _ifparser = self.ifparser
+        self.assertEqual(len(_ifparser.interfaces), 1)
+        self.assertEqual(_ifparser.interfaces,
+                         ['enp135s0f0'])
+        interface = _ifparser.get_interface('enp135s0f0')
+        values = interface.get_values()
+        self.assertEqual(True, values['SLAVE'])


### PR DESCRIPTION
* added SLAVE field to _flag_list to support slave interfaces
  for network bonding.
* also updated README to include the entire _flag_list

Closes: #10